### PR TITLE
Table of Contents + Bugfixes

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -935,11 +935,11 @@ function socialwiki_delete_comments_wiki() {
 function socialwiki_print_page_content($page, $context, $swid) {
     global $PAGE, $USER;
     $content = socialwiki_parse_content($page->format, $page->content, array('swid' => $swid, 'pageid' => $page->id));
-    $html = file_rewrite_pluginfile_urls($content['toc'] . $content['parsed_text'], 'pluginfile.php',
+    $html = file_rewrite_pluginfile_urls($content['parsed_text'], 'pluginfile.php',
             $context->id, 'mod_socialwiki', 'attachments', $swid);
     $wikioutput = $PAGE->get_renderer('mod_socialwiki');
     // This is where the page content, from the title down, is rendered!
-    echo $wikioutput->viewing_area(format_text($html, FORMAT_MOODLE, array('overflowdiv' => true, 'allowid' => true)), $page);
+    echo $wikioutput->viewing_area($content['toc'] . format_text($html, FORMAT_MOODLE, array('overflowdiv' => true, 'allowid' => true)), $page);
 
     // Only increment page view when linked, not refreshed.
     $pagerefreshed = (null !== filter_input(INPUT_SERVER, 'HTTP_CACHE_CONTROL'))

--- a/parser/markups/wikimarkup.php
+++ b/parser/markups/wikimarkup.php
@@ -203,6 +203,7 @@ abstract class socialwiki_markup_parser extends socialgeneric_parser {
             }
 
             $toc .= '<li class="socialwiki-toc-section">' . socialparser_utils::h('a', $header[1], array('href' => "#toc-$i"));
+            $currenttype = $header[0];
             $i++;
         }
         $this->returnvalues['toc'] = "<nav role='directory' class='socialwiki-toc'><h4 class='socialwiki-toc-title'>"

--- a/parser/markups/wikimarkup.php
+++ b/parser/markups/wikimarkup.php
@@ -195,45 +195,26 @@ abstract class socialwiki_markup_parser extends socialgeneric_parser {
         }
 
         $toc = "";
-        $currentsection = array(0, 0, 0);
+        $currenttype = 1;
         $i = 1;
-        foreach ($this->toc as & $header) {
-            switch ($header[0]) {
-                case 1:
-                    $currentsection = array($currentsection[0] + 1, 0, 0);
-                    break;
-                case 2:
-                    $currentsection[1] ++;
-                    $currentsection[2] = 0;
-                    if ($currentsection[0] == 0) {
-                        $currentsection[0] ++;
-                    }
-                    break;
-                case 3:
-                    $currentsection[2] ++;
-                    if ($currentsection[1] == 0) {
-                        $currentsection[1] ++;
-                    }
-                    if ($currentsection[0] == 0) {
-                        $currentsection[0] ++;
-                    }
-                    break;
-                default:
-                    continue;
-            }
-            $number = "$currentsection[0]";
-            if (!empty($currentsection[1])) {
-                $number .= ".$currentsection[1]";
-                if (!empty($currentsection[2])) {
-                    $number .= ".$currentsection[2]";
+        foreach ($this->toc as &$header) {
+            if ($header[0] > $currenttype) {
+                for ($t = 0; $t < $header[0] - $currenttype; $t++) {
+                    $toc .= '<ol>';
                 }
+            } else if ($header[0] < $currenttype) {
+                for ($t = 0; $t < $currenttype - $header[0]; $t++) {
+                    $toc .= '</ol></li>';
+                }
+            } else if (i !== 1) {
+                $toc .= '</li>';
             }
-            $toc .= socialparser_utils::h('p', $number . ". " . socialparser_utils::h('a', $header[1], array('href' => "#toc-$i")),
-                    array('class' => 'socialwiki-toc-section-' . $header[0] . " socialwiki-toc-section"));
+
+            $toc .= '<li class="socialwiki-toc-section">' . socialparser_utils::h('a', $header[1], array('href' => "#toc-$i"));
             $i++;
         }
-        $this->returnvalues['toc'] = "<div class='socialwiki-toc'><p class='socialwiki-toc-title'>"
-                . get_string('tableofcontents', 'socialwiki') . "</p>$toc</div>";
+        $this->returnvalues['toc'] = "<nav class='socialwiki-toc' role='directory'><h4 class='socialwiki-toc-title'>"
+                . get_string('tableofcontents', 'socialwiki') . "</h4><ol>$toc</ol></nav>";
     }
 
     /**

--- a/parser/markups/wikimarkup.php
+++ b/parser/markups/wikimarkup.php
@@ -198,23 +198,29 @@ abstract class socialwiki_markup_parser extends socialgeneric_parser {
         $currenttype = 1;
         $i = 1;
         foreach ($this->toc as &$header) {
-            if ($header[0] > $currenttype) {
-                for ($t = 0; $t < $header[0] - $currenttype; $t++) {
-                    $toc .= '<ol>';
-                }
-            } else if ($header[0] < $currenttype) {
-                for ($t = 0; $t < $currenttype - $header[0]; $t++) {
-                    $toc .= '</ol></li>';
-                }
-            } else if (i !== 1) {
-                $toc .= '</li>';
+            if ($i !== 1) {
+                $toc .= $this->process_toc_level($header[0], $currenttype);
             }
 
             $toc .= '<li class="socialwiki-toc-section">' . socialparser_utils::h('a', $header[1], array('href' => "#toc-$i"));
             $i++;
         }
-        $this->returnvalues['toc'] = "<nav class='socialwiki-toc' role='directory'><h4 class='socialwiki-toc-title'>"
+        $this->returnvalues['toc'] = "<nav role='directory' class='socialwiki-toc'><h4 class='socialwiki-toc-title'>"
                 . get_string('tableofcontents', 'socialwiki') . "</h4><ol>$toc</ol></nav>";
+    }
+
+    private function process_toc_level($next, $current) {
+        if ($next > $current) {
+            for ($t = 0; $t < $next - $current; $t++) {
+                return '<ol>';
+            }
+        } else if ($next < $current) {
+            for ($t = 0; $t < $current - $next; $t++) {
+                return '</ol></li>';
+            }
+        } else {
+            return '</li>';
+        }
     }
 
     /**

--- a/styles.css
+++ b/styles.css
@@ -79,12 +79,21 @@
     padding: 8px;
     background: #f5f5f5;
     border: 1px solid #e3e3e3;
-    -webkit-border-radius: 4px;
-    -moz-border-radius: 4px;
     border-radius: 4px;
-    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,0.05);
-    -moz-box-shadow: inset 0 1px 1px rgba(0,0,0,0.05);
     box-shadow: inset 0 1px 1px rgba(0,0,0,0.05);
+}
+
+.socialwiki_wikicontent .socialwiki-toc ol {
+    counter-reset: item;
+}
+
+.socialwiki_wikicontent .socialwiki-toc ol>li {
+    display: block;
+}
+
+.socialwiki_wikicontent .socialwiki-toc ol>li:before {
+    content: counters(item, ".") ". ";
+    counter-increment: item;
 }
 
 .socialwiki_wikicontent .socialwiki-toc-title {
@@ -98,14 +107,6 @@
 .socialwiki_wikicontent .socialwiki-toc-section {
     padding: 0;
     margin: 2px 8px;
-}
-
-.socialwiki_wikicontent .socialwiki-toc-section-2 {
-    padding-left: 12px;
-}
-
-.socialwiki_wikicontent .socialwiki-toc-section-3 {
-    padding-left: 24px;
 }
 
 .socialwiki_wikicontent .socialwiki-form-button {

--- a/styles.css
+++ b/styles.css
@@ -271,6 +271,11 @@
     margin-bottom: 0.4em;
 }
 
+.socialwiki_wikicontent .singleselect {
+    position: relative;
+    z-index: 1;
+}
+
 .socialwiki_wikicontent .socialwiki-attachment:before {
     content: url("/mod/socialwiki/pix/attachment.png");
     padding-right: 2px;

--- a/table/table.js
+++ b/table/table.js
@@ -86,5 +86,5 @@ $.fn.dataTable.ext.type.order['contrib-pre'] = function (d) {
  */
 $.fn.dataTable.ext.type.order['distance-pre'] = function (d) {
     var dist = parseInt(d[13]);
-    return ((dist === 1) ? 5 : dist);
+    return ((dist === 1) ? 9 : dist);
 };

--- a/table/usertable.php
+++ b/table/usertable.php
@@ -122,7 +122,7 @@ class socialwiki_usertable extends socialwiki_table {
                 'likesim' => round($peer->likesim * 100 ) . '%',
                 'followsim' => round($peer->followsim * 100 ) . '%',
                 'networkdistance' => "<span value=$peer->depth>"
-                    . get_string('distance' . $peer->depth, 'socialwiki') . '</span>'
+                    . get_string('distance' . ($peer->depth > 3 ? 3 : $peer->depth), 'socialwiki') . '</span>'
             );
 
             foreach ($headers as $key) {

--- a/table/versiontable.php
+++ b/table/versiontable.php
@@ -89,15 +89,11 @@ class socialwiki_versiontable extends socialwiki_table {
                     . "$CFG->wwwroot/mod/socialwiki/view.php?pageid=$page->id>$page->title</a>";
 
             if (socialwiki_liked($this->uid, $page->id)) {
-                $unlikeimg = "<img style='width:22px;' class='socialwiki_unlikeimg unlikeimg_$page->id' "
-                        . "alt='unlikeimg_$page->id' src='$CFG->wwwroot/mod/socialwiki/pix/icons/unlike.png'></img>";
-                $likeimg = "<img style='width:22px; display:none;' class='socialwiki_likeimg likeimg_$page->id' "
-                        . "alt='likeimg_$page->id' src='$CFG->wwwroot/mod/socialwiki/pix/icons/like.png'></img>";
+                $likeimg = "<img style='width:22px' class='socialwiki_unlikeimg unlikeimg_$page->id' "
+                        . "alt='unlikeimg_$page->id' src='$CFG->wwwroot/mod/socialwiki/pix/icons/unlike.png'>";
             } else {
-                $unlikeimg = "<img style='width:22px; display:none;' class='socialwiki_unlikeimg unlikeimg_$page->id'  "
-                        . "alt='unlikeimg_$page->id' src='$CFG->wwwroot/mod/socialwiki/pix/icons/unlike.png'></img>";
-                $likeimg = "<img style='width:22px;' class='socialwiki_likeimg likeimg_$page->id'  "
-                        . "alt='likeimg_$page->id' src='$CFG->wwwroot/mod/socialwiki/pix/icons/like.png'></img>";
+                $likeimg = "<img style='width:22px' class='socialwiki_likeimg likeimg_$page->id'  "
+                        . "alt='likeimg_$page->id' src='$CFG->wwwroot/mod/socialwiki/pix/icons/like.png'>";
             }
 
             // Favourites.
@@ -113,7 +109,7 @@ class socialwiki_versiontable extends socialwiki_table {
             $distance = $this->combine_indicators($page, $combiner, "networkdistance");
 
             $row = array(
-                'title' => "<div>$likeimg$unlikeimg$linkpage</div>",
+                'title' => $likeimg.$linkpage,
                 'contributors' => $contribstring,
                 'updated' => "<span value='{$page->timecreated}'>" . socialwiki_format_time($page->timecreated) . "</span>",
                 'likes' => $likes,
@@ -201,16 +197,13 @@ class socialwiki_versiontable extends socialwiki_table {
         switch ($reducer) {
             case "max":
                 return max($uservals);
-
             case "min":
                 return min($uservals);
-
             case "avg":
                 $len = count($uservals);
                 return (array_reduce($uservals, function($a, $b) {
                             return $a + $b;
                 }) / $len);
-
             case "sum":
                 return array_reduce($uservals, function($a, $b) {
                     return $a + $b;

--- a/tree/tree.js
+++ b/tree/tree.js
@@ -32,9 +32,7 @@ $(document).ready(function() {
     var element = document.getElementById('doublescroll');
     var scrollbar = document.createElement('div');
     scrollbar.appendChild(document.createElement('div'));
-    scrollbar.style.overflow = 'auto';
     scrollbar.style.overflowY = 'hidden';
-    scrollbar.style.width = element.width;
     scrollbar.firstChild.style.width = element.scrollWidth + 'px';
     scrollbar.firstChild.style.paddingTop = '10px';
     scrollbar.onscroll = function () {
@@ -45,24 +43,27 @@ $(document).ready(function() {
     };
     element.parentNode.insertBefore(scrollbar, element);
 
+    scrollbar.scrollLeft = (element.scrollWidth-element.offsetWidth)/2;
+    element.scrollLeft = scrollbar.scrollLeft;
     /**
      * Enable the compare button if 2 nodes have been selected.
      */
     var compare = false;
     var comparewith = false;
-    $('input[type="submit"]#comparebtn').prop('disabled', true);
-    $('input[type=radio]').change(function() {
-        var name = $(this).attr("name");
+    document.getElementById('comparebtn').disabled = true;
+    var radio = document.querySelectorAll('input[type=radio]');
+    for (var i = 0; i < radio.length; i++)
+    radio[i].onchange = function() {
+        var name = this.getAttribute("name");
         if (name === 'compare') {
             compare = true;
-        }
-        else if (name === 'comparewith') {
+        } else if (name === 'comparewith') {
             comparewith = true;
         }
         if (compare && comparewith) {
-            $('input[type="submit"]#comparebtn').prop('disabled', false);
+            document.getElementById('comparebtn').disabled = false;
         }
-    });
+    };
 
     /**
      * The Hide Button.


### PR DESCRIPTION
- Rebuilt the table of contents to take advantage of styling to show listed numbers and layout
- Added proper ARIA roles to table of contents to work properly with screen readers

- The scroll bar in the tree view is now automatically centered
- Fixed an issue where the peer depth is greater than 3 and a string would be missing
- The version table no longer grabs both the like and unlike images for each row since only one is used

@esfandia 