### PR TITLE
Restore fix + Comments + Capability checking

### DIFF
--- a/backup/moodle2/restore_socialwiki_stepslib.php
+++ b/backup/moodle2/restore_socialwiki_stepslib.php
@@ -83,11 +83,11 @@ class restore_socialwiki_activity_structure_step extends restore_activity_struct
     }
 
     protected function process_socialwiki_page($data) {
-        global $DB, $USER;
+        global $DB;
         $data = (object) $data;
         $oldid = $data->id;
         $data->subwikiid = $this->get_new_parentid('socialwiki_subwiki');
-        $data->userid = $USER->id;
+        $data->userid = $this->get_mappingid('user', $data->userid);
         $data->timecreated = $this->apply_date_offset($data->timecreated);
         $data->parent = $this->get_mappingid('socialwiki_page', $data->parent);
 

--- a/create.php
+++ b/create.php
@@ -25,9 +25,9 @@
  */
 
 require('../../config.php');
-require($CFG->dirroot . '/mod/socialwiki/create_form.php');
 require($CFG->dirroot . '/mod/socialwiki/locallib.php');
 require($CFG->dirroot . '/mod/socialwiki/pagelib.php');
+require($CFG->dirroot . '/mod/socialwiki/create_form.php');
 
 // New action will display a form contains page title and page format selections.
 // Create action will create a new page in db, and redirect to page editing page.

--- a/editcomments.php
+++ b/editcomments.php
@@ -54,17 +54,18 @@ if (!$wiki = socialwiki_get_wiki($subwiki->wikiid)) {
 }
 require_login($course, true, $cm);
 
-$editcomments = new page_socialwiki_editcomment($wiki, $subwiki, $cm);
+$comm = new page_socialwiki_editcomment($wiki, $subwiki, $cm);
 $comment = new stdClass();
+// Get comment if editing.
 if ($action == 'edit') {
     if (!$comment = $DB->get_record('comments', array('id' => $comid))) {
         print_error('invalidcomment', 'socialwiki');
     }
 }
 
-$editcomments->set_page($page);
-$editcomments->set_action($action, $comment);
+$comm->set_page($page);
+$comm->set_action($action, $comment);
 
-$editcomments->print_header();
-$editcomments->print_content();
-$editcomments->print_footer();
+$comm->print_header();
+$comm->print_content();
+$comm->print_footer();

--- a/follow.php
+++ b/follow.php
@@ -45,27 +45,19 @@ if ($pageid > -1) {
     if (!$page = socialwiki_get_page($pageid)) {
         print_error('incorrectpageid', 'socialwiki');
     }
-
     if (!$subwiki = socialwiki_get_subwiki($page->subwikiid)) {
         print_error('incorrectsubwikiid', 'socialwiki');
     }
-
     if (!$wiki = socialwiki_get_wiki($subwiki->wikiid)) {
         print_error('incorrectwikiid', 'socialwiki');
     }
-
     if (!$cm = get_coursemodule_from_instance('socialwiki', $wiki->id)) {
         print_error('invalidcoursemodule', 'socialwiki');
     }
-    $context = get_context_instance(CONTEXT_MODULE, $cm->id);
-
-    if (!is_enrolled($context, $USER->id)) {
-        // Must be an enrolled user to follow someone.
-        print_error('deniedfollow', 'socialwiki');
-    }
+    require_capability('mod/socialwiki:editpage', context_module::instance($cm->id));
 
     // Get the author of the current page.
-    $page = socialwiki_get_page($pageid, 0);
+    $page = socialwiki_get_page($pageid);
     $user2 = $page->userid;
     // Check if the user is following themselves.
     if ($USER->id == $user2) {

--- a/instancecomments.php
+++ b/instancecomments.php
@@ -32,8 +32,8 @@
  */
 
 require_once('../../config.php');
-require_once($CFG->dirroot . "/mod/socialwiki/pagelib.php");
 require_once($CFG->dirroot . "/mod/socialwiki/locallib.php");
+require_once($CFG->dirroot . "/mod/socialwiki/pagelib.php");
 require_once($CFG->dirroot . '/mod/socialwiki/comments_form.php');
 
 $pageid     = required_param('pageid', PARAM_TEXT);
@@ -46,7 +46,6 @@ $confirm    = optional_param('confirm', 0, PARAM_BOOL);
 if (!$page = socialwiki_get_page($pageid)) {
     print_error('incorrectpageid', 'socialwiki');
 }
-
 if (!$subwiki = socialwiki_get_subwiki($page->subwikiid)) {
     print_error('incorrectsubwikiid', 'socialwiki');
 }
@@ -59,29 +58,24 @@ if (!$wiki = socialwiki_get_wiki($subwiki->wikiid)) {
 }
 require_login($course, true, $cm);
 
-if ($action == 'add' || $action == 'edit') {
-    // Just check sesskey.
+// Create correct page.
+if ($action == 'delete' && !$confirm) {
+    // Confirm the use would like to delete the comment.
+    $comm = new page_socialwiki_deletecomment($wiki, $subwiki, $cm);
+} else {
+    // Check sesskey for modifications.
     if (!confirm_sesskey()) {
         print_error(get_string('invalidsesskey', 'socialwiki'));
     }
-    $comm = new page_socialwiki_handlecomments($wiki, $subwiki, $cm);
-    $comm->set_page($page);
-} else {
-    if (!$confirm) {
-        $comm = new page_socialwiki_deletecomment($wiki, $subwiki, $cm);
-        $comm->set_page($page);
-        $comm->set_url();
-    } else {
-        $comm = new page_socialwiki_handlecomments($wiki, $subwiki, $cm);
-        $comm->set_page($page);
-        if (!confirm_sesskey()) {
-            print_error(get_string('invalidsesskey', 'socialwiki'));
-        }
-    }
+    // Handle add, edit, delete.
+    $comm = new page_socialwiki_handlecomment($wiki, $subwiki, $cm);
 }
+$comm->set_page($page);
 
+// Set correct action.
 if ($action == 'delete') {
-    $comm->set_action($action, $commentid, 0);
+    // Hand over commentid.
+    $comm->set_action($action, $commentid);
 } else {
     if (empty($newcontent)) {
         $form = new mod_socialwiki_comments_form();

--- a/lang/en/socialwiki.php
+++ b/lang/en/socialwiki.php
@@ -73,7 +73,7 @@ $string['like_tip'] = 'Like/Unlike this page';
 
 $string['deletecomment'] = 'Deleting comment';
 $string['deletecommentcheck'] = 'Delete comment';
-$string['deletecommentcheckfull'] = 'Are you sure you want to delete the comment?';
+$string['deletecommentcheckfull'] = 'Are you sure you want to delete this comment?';
 $string['deleteupload'] = 'Delete';
 $string['deletedbegins'] = 'Deleted begins';
 $string['deletedends'] = 'Deleted ends';

--- a/like.ajax.php
+++ b/like.ajax.php
@@ -44,10 +44,7 @@ if (!$wiki = socialwiki_get_wiki($subwiki->wikiid)) {
 if (!$cm = get_coursemodule_from_instance('socialwiki', $wiki->id)) {
     print_error('invalidcoursemodule', 'socialwiki');
 }
-if (!is_enrolled(context_module::instance($cm->id), $USER->id)) {
-    // Must be an enrolled user to like a page.
-    print_error('cannotlike', 'socialwiki');
-}
+require_capability('mod/socialwiki:editpage', context_module::instance($cm->id));
 
 $out = "";
 if (confirm_sesskey()) {

--- a/like.php
+++ b/like.php
@@ -42,10 +42,7 @@ if (!$wiki = socialwiki_get_wiki($subwiki->wikiid)) {
 if (!$cm = get_coursemodule_from_instance('socialwiki', $wiki->id)) {
     print_error('invalidcoursemodule', 'socialwiki');
 }
-if (!is_enrolled(context_module::instance($cm->id), $USER->id)) {
-    // Must be an enrolled user to like a page.
-    print_error('cannotlike', 'socialwiki');
-}
+require_capability('mod/socialwiki:editpage', context_module::instance($cm->id));
 
 if (confirm_sesskey()) {
     $out = socialwiki_page_like($USER->id, $pageid, $subwiki->id);

--- a/locallib.php
+++ b/locallib.php
@@ -1693,25 +1693,10 @@ function socialwiki_follow_depth($userfrom, $userto, $swid, $depth = 1, &$checke
  */
 function socialwiki_format_time($time, $timeago = true) {
     // Standard day, month, year format.
-    $date = strftime('%d %b %Y', $time);
     if (!$timeago) {
-        return $date;
+        return strftime('%d %b %Y', $time);
     }
 
-    // Return the time based upon how long ago from the current time.
-    $diff = (new DateTime)->diff(new DateTime('@' . $time));
-    $types = array(
-        'y' => 'year',
-        'm' => 'month',
-        'd' => 'day',
-        'h' => 'hour',
-        'i' => 'minute',
-        's' => 'second',
-    );
-    // Loops through to return the first type available.
-    foreach ($types as $t => &$i) {
-        if ($diff->$t) {
-            return "<span title='$date'>" . $diff->$t . ' ' . $i . ($diff->$t > 1 ? 's' : "") . ' ago</span>';
-        }
-    }
+    // Standard Moodle time ago formatting.
+    return format_time(time() - $time) . " ago";
 }

--- a/pagelib.php
+++ b/pagelib.php
@@ -427,6 +427,11 @@ class page_socialwiki_view extends page_socialwiki {
                 . "{$this->page->id}'>" . get_string('addcomment', 'socialwiki') . "</a></div>";
         }
 
+        if (count($comments) == 0) {
+            // No comments to display.
+            return;
+        }
+
         // Show reversible button.
         echo '<a id="socialwiki-comdirection" other="' . get_string('commentoldest', 'socialwiki') . '")>' . get_string('commentnewest', 'socialwiki') .'</a>';
 
@@ -437,16 +442,16 @@ class page_socialwiki_view extends page_socialwiki {
 
             // Get the user name and date of posting.
             $info = '<b><a href="' . $CFG->wwwroot . '/mod/socialwiki/viewuserpages.php?userid='
-                . $user->id . '&amp;subwikiid=' . $this->page->subwikiid . '">'
-                . fullname($user, has_capability('moodle/site:viewfullnames', context_course::instance($course->id)))
-                . '</a></b> ' . socialwiki_format_time($comment->timecreated) . ' ';
+                    . $user->id . '&amp;subwikiid=' . $this->page->subwikiid . '">'
+                    . fullname($user, has_capability('moodle/site:viewfullnames', context_course::instance($course->id)))
+                    . '</a></b> ' . socialwiki_format_time($comment->timecreated) . ' ';
 
             // Check if edit and delete icons should be shown.
             if (has_capability('mod/socialwiki:managecomment', $this->modcontext) || (has_capability('mod/socialwiki:editcomment', $this->modcontext) && $USER->id == $user->id)) {
                 $urledit = new moodle_url('/mod/socialwiki/editcomments.php',
-                    array('commentid' => $comment->id, 'pageid' => $this->page->id, 'action' => 'edit'));
+                        array('commentid' => $comment->id, 'pageid' => $this->page->id, 'action' => 'edit'));
                 $urldelet = new moodle_url('/mod/socialwiki/instancecomments.php',
-                    array('commentid' => $comment->id, 'pageid' => $this->page->id, 'action' => 'delete'));
+                        array('commentid' => $comment->id, 'pageid' => $this->page->id, 'action' => 'delete'));
                 $info .= $OUTPUT->action_icon($urledit, new pix_icon('t/edit', get_string('edit'), "",
                         array('class' => 'iconsmall'))) . $OUTPUT->action_icon($urldelet,
                         new pix_icon('t/delete', get_string('delete'), "", array('class' => 'iconsmall')));

--- a/peer.php
+++ b/peer.php
@@ -185,7 +185,7 @@ class socialwiki_peer {
      * @param int $id A user ID.
      * @param int $swid The subwiki ID.
      * @param int $thisuser The current user ID.
-     * @return peer
+     * @return stdClass peer
      */
     public static function socialwiki_get_peer($id, $swid, $thisuser = null) {
         Global $USER;

--- a/print.css
+++ b/print.css
@@ -1,17 +1,6 @@
 @media print {
-    body {
-        visibility: hidden;
-    }
-
-    #socialwiki_content_area {
-        visibility: visible;
-        position: absolute;
-        top: 20px;
-        left: 0;
-        width: 100%;
-    }
-
-    .nav-tabs, .socialwiki-likebutton, #block-region-side-pre, #page-footer {
+    #socialwiki-comdirection, .midpad, button, header,
+    .breadcrumb, #page-navbar, .nav-tabs, #block-region-side-pre, #page-footer {
         display: none;
     }
 }

--- a/print.css
+++ b/print.css
@@ -1,6 +1,10 @@
 @media print {
-    #socialwiki-comdirection, .midpad, button, header,
+    #socialwiki-comdirection, .action-icon, .midpad, button, header,
     .breadcrumb, #page-navbar, .nav-tabs, #block-region-side-pre, #page-footer {
         display: none;
+    }
+
+    #region-main {
+        width: 100% !important;
     }
 }


### PR DESCRIPTION
- Fixed author names being removed when restoring a backup
- Switched to built in Moodle time formatting to match usual time stamps and remove extra code
- Do not show ordering on comments if there is no ordering needed
- When confirming comment deletion show the comment you are deleting
- Reorganized file requiring and cut out unneeded variables and logic
- Check if you are able to like/follow/make a new page before showing the button to do so
- Significant changes to print styling to look better and fix issues with different browsers

@esfandia 